### PR TITLE
docs: reverse the changlog order, make it more friendly to package user

### DIFF
--- a/CHANGELOG-ZH.md
+++ b/CHANGELOG-ZH.md
@@ -1,3 +1,61 @@
+## [1.0.7] - [2018/09/02]
+    * 在Swiper dispose的时候不调用Controller的dispose.
+
+## [1.0.6] - [2018/08/28]
+    * `TINDER` 和 `STACK` 这两种布局方式实现垂直滚动, #9
+
+## [1.0.5] - [2018/08/09]
+    * viewportFraction<1.0增加fade参数
+
+## [1.0.4] - [2018/07/18]
+    * 修复一些错别字，感谢[csharad](https://github.com/csharad)
+   
+## [1.0.3] - [2018/07/18]
+    * 根据#5 ,用new来创建对象
+
+## [1.0.2] - [2018/07/16]
+    * 修复 #4
+
+## [1.0.1] - [2018/07/11]
+    * 支持布局方式(CUSTOM),你可以定制你自己的布局
+    
+## [1.0.0] - [2018/07/08]
+    * 增加布局方式( DEFAULT,STACK,TINDER )
+    * 可以将分页指示器放在容器外面
+
+## [0.0.9] - [2018/06/10]
+    * 增加CI
+    * 增加测试用例
+
+## [0.0.8] - [2018/06/07]
+    * 新增中文文档
+    * 更新依赖包：infinity_page_view 版本到 1.0.0
+
+## [0.0.7] - [2018/05/24]
+    * The default color of pagination is ThemeData.scaffoldBackgroundColor and ThemeData.primaryColor
+    * The default color of control buttons is ThemeData.primaryColor and ThemeData.disabledColor
+    * The alignment of pagination is Alignment.bottomCenter by default when scrollDirection== Axis.horizontal, Alignment.centerRight by default when scrollDirection== Axis.vertical
+    * Change default value of `autoplay` to false
+
+## [0.0.6] - [2018/05/24]
+    * Fix index bug
+
+## [0.0.5] - [2018/05/24]
+    * Fix zero itemCount bug
+    
+## [0.0.4] - [2018/05/20]
+    * Update README
+
+## [0.0.3] - [2018/05/20]
+    * Update README
+    * Support none loop mode
+    * Add more examples
+
+## [0.0.2] - [2018/05/20]
+    * Autoplay
+    * Plugins support 
+    * Examples
+
 ## [0.0.1] - [2018/05/20]
     * Infinite loop
     * Control buttons
@@ -5,56 +63,3 @@
     * Custom control buttons
     * Custom pagination
     * Controler
-    
-## [0.0.2] - [2018/05/20]
-    * Autoplay
-    * Plugins support 
-    * Examples
-    
-## [0.0.3] - [2018/05/20]
-    * Update README
-    * Support none loop mode
-    * Add more examples
-    
-## [0.0.4] - [2018/05/20]
-    * Update README
-    
-## [0.0.5] - [2018/05/24]
-    * Fix zero itemCount bug
- 
-## [0.0.6] - [2018/05/24]
-    * Fix index bug
-        
-## [0.0.7] - [2018/05/24]
-    * The default color of pagination is ThemeData.scaffoldBackgroundColor and ThemeData.primaryColor
-    * The default color of control buttons is ThemeData.primaryColor and ThemeData.disabledColor
-    * The alignment of pagination is Alignment.bottomCenter by default when scrollDirection== Axis.horizontal, Alignment.centerRight by default when scrollDirection== Axis.vertical
-    * Change default value of `autoplay` to false
-    
-    
-## [0.0.8] - [2018/06/07]
-    * 新增中文文档
-    * 更新依赖包：infinity_page_view 版本到 1.0.0
-    
-## [1.0.0] - [2018/07/08]
-    * 增加布局方式( DEFAULT,STACK,TINDER )
-    * 可以将分页指示器放在容器外面
-## [1.0.1] - [2018/07/11]
-    * 支持布局方式(CUSTOM),你可以定制你自己的布局
-## [1.0.2] - [2018/07/16]
-    * 修复 #4
-    
-## [1.0.3] - [2018/07/18]
-    * 根据#5 ,用new来创建对象
-
-## [1.0.4] - [2018/07/18]
-    * 修复一些错别字，感谢[csharad](https://github.com/csharad)
-    
-## [1.0.5] - [2018/08/09]
-    * viewportFraction<1.0增加fade参数
-    
-## [1.0.6] - [2018/08/28]
-    * `TINDER` 和 `STACK` 这两种布局方式实现垂直滚动, #9
-
-## [1.0.7] - [2018/09/02]
-    * 在Swiper dispose的时候不调用Controller的dispose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,61 @@
+## [1.0.7] - [2018/09/02]
+    * Don't call SwiperController's dispose when `Swiper` dispose.
+
+## [1.0.6] - [2018/08/28]
+    * Implement vertical scroll direction for `TINDER` and `STACK` layout, see #9
+
+## [1.0.5] - [2018/08/09]
+    * Add feature : support fade for `viewportFraction`
+
+## [1.0.4] - [2018/07/18]
+    * Fix some typo,thanks to [csharad](https://github.com/csharad)
+
+## [1.0.3] - [2018/07/18]
+    * Use new to create everything. See #5
+
+## [1.0.2] - [2018/07/16]
+    * Fix #4
+
+## [1.0.1] - [2018/07/11]
+    * Add layout (CUSTOM) so that you can create your own layout
+
+## [1.0.0] - [2018/07/08]
+    * Add layouts ( DEFAULT,STACK,TINDER )
+    * Allow to put pagination outer of the swiper container.
+
+## [0.0.9] - [2018/06/10]
+    * Add ci
+    * Add testcase
+
+## [0.0.8] - [2018/06/07]
+    * And chinese document
+    * Update infinity_page_view version to 1.0.0
+
+## [0.0.7] - [2018/05/24]
+    * The default color of pagination is ThemeData.scaffoldBackgroundColor and ThemeData.primaryColor
+    * The default color of control buttons is ThemeData.primaryColor and ThemeData.disabledColor
+    * The alignment of pagination is Alignment.bottomCenter by default when scrollDirection== Axis.horizontal, Alignment.centerRight by default when scrollDirection== Axis.vertical
+    * Change default value of `autoplay` to false
+
+## [0.0.6] - [2018/05/24]
+    * Fix index bug
+        
+## [0.0.5] - [2018/05/24]
+    * Fix zero itemCount bug
+
+## [0.0.4] - [2018/05/20]
+    * Update README
+
+## [0.0.3] - [2018/05/20]
+    * Update README
+    * Support none loop mode
+    * Add more examples
+
+## [0.0.2] - [2018/05/20]
+    * Autoplay
+    * Plugins support 
+    * Examples
+
 ## [0.0.1] - [2018/05/20]
     * Infinite loop
     * Control buttons
@@ -5,62 +63,3 @@
     * Custom control buttons
     * Custom pagination
     * Controler
-    
-## [0.0.2] - [2018/05/20]
-    * Autoplay
-    * Plugins support 
-    * Examples
-    
-## [0.0.3] - [2018/05/20]
-    * Update README
-    * Support none loop mode
-    * Add more examples
-    
-## [0.0.4] - [2018/05/20]
-    * Update README
-    
-## [0.0.5] - [2018/05/24]
-    * Fix zero itemCount bug
- 
-## [0.0.6] - [2018/05/24]
-    * Fix index bug
-        
-## [0.0.7] - [2018/05/24]
-    * The default color of pagination is ThemeData.scaffoldBackgroundColor and ThemeData.primaryColor
-    * The default color of control buttons is ThemeData.primaryColor and ThemeData.disabledColor
-    * The alignment of pagination is Alignment.bottomCenter by default when scrollDirection== Axis.horizontal, Alignment.centerRight by default when scrollDirection== Axis.vertical
-    * Change default value of `autoplay` to false
-    
-    
-## [0.0.8] - [2018/06/07]
-    * And chinese document
-    * Update infinity_page_view version to 1.0.0
-    
-## [0.0.9] - [2018/06/10]
-    * Add ci
-    * Add testcase
-
-## [1.0.0] - [2018/07/08]
-    * Add layouts ( DEFAULT,STACK,TINDER )
-    * Allow to put pagination outer of the swiper container.
-
-## [1.0.1] - [2018/07/11]
-    * Add layout (CUSTOM) so that you can create your own layout
-
-## [1.0.2] - [2018/07/16]
-    * Fix #4
-
-## [1.0.3] - [2018/07/18]
-    * Use new to create everything. See #5
-    
-## [1.0.4] - [2018/07/18]
-    * Fix some typo,thanks to [csharad](https://github.com/csharad)
-
-## [1.0.5] - [2018/08/09]
-    * Add feature : support fade for `viewportFraction`
-
-## [1.0.6] - [2018/08/28]
-    * Implement vertical scroll direction for `TINDER` and `STACK` layout, see #9
-
-## [1.0.7] - [2018/09/02]
-    * Don't call SwiperController's dispose when `Swiper` dispose.


### PR DESCRIPTION
#### `Pull request type - docs`
- [X] Documentation content changes
#### Hi , jzoom
First, thank u for your awesome flutter lib. When I read the project's changelog, I find a problem. Your changlog start at first release, I think `reverse the changlog order will be more friendly` to package user.
What do you think?
For example ( from the pub.dartlang.org )
<img width="300px" src="https://user-images.githubusercontent.com/14012511/45252118-623cb200-b384-11e8-8aa0-1f63f38ac38f.png">
> btw: Can I join your `best-flutter` github team ?
> I am a front-end engineer at *www.pinduoduo.com*, If you want to find a better job, you can contact with me.  
