### PR TITLE
Bug index reset to zero

### DIFF
--- a/lib/src/custom_layout.dart
+++ b/lib/src/custom_layout.dart
@@ -11,6 +11,8 @@ abstract class _CustomLayoutStateBase<T extends _SubSwiper> extends State<T>
 
   @override
   void initState() {
+    if(widget.index != null)
+      _currentIndex = widget.index;
     if (widget.itemWidth == null) {
       throw new Exception(
           "==============\n\nwidget.itemWith must not be null when use stack layout.\n========\n");
@@ -39,6 +41,7 @@ abstract class _CustomLayoutStateBase<T extends _SubSwiper> extends State<T>
 
   @mustCallSuper
   void afterRender() {
+    if(context == null) return;
     RenderObject renderObject = context.findRenderObject();
     Size size = renderObject.paintBounds.size;
     _swiperWidth = size.width;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_swiper
 description: The best swiper(carousel) for flutter, with multiple layouts, infinite loop. Compatible with Android & iOS.
-version: 1.1.7
+version: 1.1.6
 author: JZoom <jzoom8112@gmail.com>
 homepage: https://github.com/jzoom/flutter_swiper
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_swiper
 description: The best swiper(carousel) for flutter, with multiple layouts, infinite loop. Compatible with Android & iOS.
-version: 1.1.6
+version: 1.1.7
 author: JZoom <jzoom8112@gmail.com>
 homepage: https://github.com/jzoom/flutter_swiper
 


### PR DESCRIPTION
Fixed the problem of indicating the selected item, 
and the error of  `Non-fatal Exception: NoSuchMethodError: The method 'findRenderObject' was called on null. Receiver: null Tried calling: findRenderObject ()`