### PR TITLE
fix a typo

### DIFF
--- a/lib/src/custom_layout.dart
+++ b/lib/src/custom_layout.dart
@@ -13,7 +13,7 @@ abstract class _CustomLayoutStateBase<T extends _SubSwiper> extends State<T>
   void initState() {
     if (widget.itemWidth == null) {
       throw new Exception(
-          "==============\n\nwidget.itemWith must not be null when use stack layout.\n========\n");
+          "==============\n\nwidget.itemWidth must not be null when use stack layout.\n========\n");
     }
 
     _createAnimationController();


### PR DESCRIPTION
Fixed a typo 

`widget.itemWith` -> `widget.itemWidth`