### PR TITLE
Fix control button enabled despite having disableColor

### DIFF
--- a/lib/src/swiper_control.dart
+++ b/lib/src/swiper_control.dart
@@ -36,10 +36,13 @@ class SwiperControl extends SwiperPlugin {
     return new GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: () {
+        ///condition onTap animation to loop status or presence of previous or next index (avoiding jump-loop).
+        bool isPrev = config.activeIndex > 0;
+        bool isNext = config.activeIndex < config.itemCount - 1;
         if (previous) {
-          config.controller.previous(animation: true);
+          if (isPrev || config.loop) config.controller.previous(animation: true);
         } else {
-          config.controller.next(animation: true);
+          if (isNext || config.loop) config.controller.next(animation: true);
         }
       },
       child: Padding(


### PR DESCRIPTION
Fixed the jump-loops caused by control buttons showing **disableColor**, by conditioning the onTap animation to a true loop status or the existence of previous or next index.