### PR TITLE
Fix the building weidget can move but can not reset automatically

### DIFF
--- a/lib/src/custom_layout.dart
+++ b/lib/src/custom_layout.dart
@@ -235,7 +235,8 @@ abstract class _CustomLayoutStateBase<T extends _SubSwiper> extends State<T>
         if (value < 0.5) {
           value = 0.5;
         }
-      } else if (_currentIndex <= 0) {
+      }
+      if (_currentIndex <= 0) {
         if (value > 0.5) {
           value = 0.5;
         }


### PR DESCRIPTION
Fix the building weidget can move but can not reset automatically  if itemCouter is only one and the mode is SwiperLayout.STACK


[see the bug](https://braineex.oss-cn-shenzhen.aliyuncs.com/Video/ae7decb74e3a4180bb111760dbf54384_0201117_115149_1.mp4)